### PR TITLE
APIに送るbase64文字を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
         const callApi = audioData => {
             const jsonData = {
                 'audio_data': audioData,
-                'encoding': 'wav',
-                'sample_rate_hertz': '16000',
+                'encoding': 'OGG_OPUS',
+                'sample_rate_hertz': '8000',
                 'language_code': 'ja-JP'
             };
             const url = 'https://asia-northeast1-icom-si2.cloudfunctions.net/create_minutes';
@@ -43,7 +43,7 @@
                 alert('議事録の作成を開始します。');
                 //audioのみtrue
                 navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
-                    const recorder = new MediaRecorder(stream);
+                    const recorder = new MediaRecorder(stream, { audioBitsPerSecond: 128000 });
                     //音を拾い続けるための配列。chunkは塊という意味
                     let chunks = [];
                     //集音のイベントを登録する
@@ -54,8 +54,12 @@
                         reader.onload = (event) => {
                             const dataUrl = reader.result;
                             // 音声のbase64データ
-                            const base64str = btoa(dataUrl);
-                            callApi(base64str).then(res => res.ok ? res.json() : Promise.reject(res.json())).then(json => json.error.code ? Promise.reject(json) : Promise.resolve(json)).then(
+                            const base64str = dataUrl.substr(dataUrl.indexOf(',') + 1);
+                            callApi(base64str).then(
+                                res => res.ok ? res.json() : Promise.reject(res.json())
+                            ).then(
+                                json => json.error.code ? Promise.reject(json) : Promise.resolve(json)
+                            ).then(
                                 data => {
                                     // Success
                                     alert('議事録の作成を終了しました。');
@@ -75,7 +79,7 @@
                                 }
                             );
                         }
-                        const blob = new Blob(chunks, { 'type': 'audio/ogg; codecs=opus' });
+                        const blob = new Blob(chunks, { 'type': 'audio/webm;codecs=opus' });
                         reader.readAsDataURL(blob);
                         chunks = [];
                     };
@@ -95,7 +99,7 @@
                         alert('stop');
                     }, ms));
                     return sleep(10000);
-                });
+                }).catch(error => console.log(`${error.name}: ${error.message}`));
             });
         });
     </script>


### PR DESCRIPTION
`api/v1/minutes`に送信する音声データを修正しました。
200で帰ってくることは確認できましたが、API側でうまくエンコードできず、認識結果が帰ってこないです。